### PR TITLE
Fix build issues, update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7.1
+osx_image: xcode7.3
 language: objective-c
 podfile: Demo/Podfile
 cache: cocoapods

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Nimble (3.0.0)
-  - Quick (0.8.0)
-  - RxBlocking (2.0.0):
-    - RxSwift (~> 2.0)
+  - Nimble (4.0.1)
+  - Quick (0.9.2)
+  - RxBlocking (2.4):
+    - RxSwift (~> 2.4)
   - RxNimble (0.1.0):
-    - Nimble (~> 3.0.0)
-    - RxBlocking (~> 2.0.0)
-    - RxSwift (~> 2.0.0)
-  - RxSwift (2.0.0)
+    - Nimble (~> 4.0)
+    - RxBlocking (~> 2.0)
+    - RxSwift (~> 2.0)
+  - RxSwift (2.4)
 
 DEPENDENCIES:
   - Nimble
@@ -16,13 +16,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   RxNimble:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Nimble: 4c353d43735b38b545cbb4cb91504588eb5de926
-  Quick: 563d0f6ec5f72e394645adb377708639b7dd38ab
-  RxBlocking: a95a10ed54eb5d116f6c9a87047ff671e181d07b
-  RxNimble: 9d5c25be85c1cb82dfcad28298e38b6160143915
-  RxSwift: d83246efa6f16c50c143bec134649d045498f601
+  Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
+  Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
+  RxBlocking: 1226c1fa0ca1e0ca5f964d4330ca3649f2128680
+  RxNimble: 6bb86c63bbff1d662535b01e53a36868c924b0c3
+  RxSwift: 67b9ef4e8b34fb394e200e754c6a09cc16559f94
 
 COCOAPODS: 0.39.0

--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -22,7 +22,7 @@ SPEC CHECKSUMS:
   Nimble: 0f3c8b8b084cda391209c3c5efbb48bedeeb920a
   Quick: 18d057bc66451eedd5d1c8dc99ba2a5db6e60226
   RxBlocking: 1226c1fa0ca1e0ca5f964d4330ca3649f2128680
-  RxNimble: 6bb86c63bbff1d662535b01e53a36868c924b0c3
+  RxNimble: 6fdc2efe09b9a305b152abd1a1d24a55bd370854
   RxSwift: 67b9ef4e8b34fb394e200e754c6a09cc16559f94
 
 COCOAPODS: 0.39.0

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/ashfurrow/RxNimble.git", :tag => s.version }
   s.source_files  = "Source/**/*.swift"
-  s.dependency "Nimble", "~> 3.0"
+  s.dependency "Nimble", "~> 4.0"
   s.dependency "RxSwift", "~> 2.0"
   s.dependency "RxBlocking", "~> 2.0"
   

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -17,4 +17,6 @@ Pod::Spec.new do |s|
   s.dependency "Nimble", "~> 3.0"
   s.dependency "RxSwift", "~> 2.0"
   s.dependency "RxBlocking", "~> 2.0"
+  
+  s.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
 end

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.dependency "RxSwift", "~> 2.0"
   s.dependency "RxBlocking", "~> 2.0"
   
-  s.pod_target_xcconfig = { 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO', 'FRAMEWORK_SEARCH_PATHS' => '$(inherited) "$(PLATFORM_DIR)/Developer/Library/Frameworks"' }
 end


### PR DESCRIPTION
1. Outdated Nimble was showing errors to me. Updated all dependencies.
2. After pods update - I was seeing "framework not found XCTest". Updated framework search path.
3. To support testing on device out of the box - disabled bitcode (fixes #7).
