### PR TITLE
Changes the Xcode message when a test fails

### DIFF
--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxNimble"
-  s.version      = "0.2.0"
+  s.version      = "0.2.1"
   s.summary      = "Nimble extensions that making unit testing with RxSwift easier 🎉"
   s.description  = <<-DESC
     This library includes functions that make testing RxSwift projects easier with Nimble.

--- a/Source/RxNimble.swift
+++ b/Source/RxNimble.swift
@@ -8,7 +8,8 @@ public func equalFirst<T: Equatable, O: ObservableType where O.E == T>(expectedV
 
         failureMessage.postfixMessage = "equal <\(expectedValue)>"
         let actualValue = try actualExpression.evaluate()?.toBlocking().first()
-
+        failureMessage.actualValue = "<\(actualValue)>"
+        
         let matches = actualValue == expectedValue
         return matches
     }
@@ -19,6 +20,7 @@ public func equalFirst<T: Equatable>(expectedValue: T?) -> MatcherFunc<Variable<
 
         failureMessage.postfixMessage = "equal <\(expectedValue)>"
         let actualValue = try actualExpression.evaluate()?.value
+        failureMessage.actualValue = "<\(actualValue)>"
 
         let matches = actualValue == expectedValue && expectedValue != nil
         return matches
@@ -30,7 +32,8 @@ public func equalFirst<T: Equatable, O: ObservableType where O.E == T?>(expected
 
         failureMessage.postfixMessage = "equal <\(expectedValue)>"
         let actualValue = try actualExpression.evaluate()?.toBlocking().first()
-
+        failureMessage.actualValue = "<\(actualValue)>"
+        
         switch actualValue {
         case .None:
             return expectedValue == nil
@@ -45,7 +48,8 @@ public func equalFirst<T: Equatable>(expectedValue: T?) -> MatcherFunc<Variable<
 
         failureMessage.postfixMessage = "equal <\(expectedValue)>"
         let actualValue = try actualExpression.evaluate()?.value
-
+        failureMessage.actualValue = "<\(actualValue)>"
+        
         switch actualValue {
         case .None:
             return expectedValue == nil


### PR DESCRIPTION
TDD is all about feedback. 
I've change the message which Xcode shown when a test fails.

How it used to be:
`expected to equal <Optional("Dummy Realnamee")>, got <RxSwift.Variable<Swift.String>>`
<img width="1412" alt="zrzut ekranu 2016-06-12 16 37 34" src="https://cloud.githubusercontent.com/assets/3684577/15991752/8020dbe0-30bc-11e6-9f67-eb332a596285.png">

How it is now:
`expected to equal <Optional("Dummy Realnamee")>, got Optional("Dummy Realname")`
<img width="1435" alt="zrzut ekranu 2016-06-12 16 35 57" src="https://cloud.githubusercontent.com/assets/3684577/15991754/8d2445c0-30bc-11e6-8ab0-963ad114d5cc.png">
