### PR TITLE
Updated podspec to Nimble 7

### DIFF
--- a/Demo/Podfile.lock
+++ b/Demo/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - Nimble (6.1.0)
-  - Quick (1.0.0)
-  - RxBlocking (3.0.1):
-    - RxSwift (~> 3.0)
+  - Nimble (7.0.0)
+  - Quick (1.1.0)
+  - RxBlocking (3.4.1):
+    - RxSwift (~> 3.4)
   - RxNimble (2.0.0):
-    - Nimble (~> 6.0)
+    - Nimble (~> 7.0)
     - RxBlocking (~> 3.0)
     - RxSwift (~> 3.0)
-  - RxSwift (3.0.1)
+  - RxSwift (3.4.1)
 
 DEPENDENCIES:
   - Nimble
@@ -16,14 +16,14 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   RxNimble:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Nimble: c53e6903fee94041b90ded74f135820437d8bf59
-  Quick: 8024e4a47e6cc03a9d5245ef0948264fc6d27cff
-  RxBlocking: 5de082d09d1ab45b49173f309f1a97d6b50f34c4
-  RxNimble: 50a9da5852b298b2ec632cb00b79fa20be9f31b8
-  RxSwift: af5680055c4ad04480189c52d28385b1029493a6
+  Nimble: 874982b605d4d752fcac6be695d13c502de84b1b
+  Quick: dafc587e21eed9f4cab3249b9f9015b0b7a7f71d
+  RxBlocking: 1e8c41cfe7ca2fc0e19d0e616c553845c63cbbd3
+  RxNimble: 0a187f22441eca11779f17ffd6565f03a3f5b1fb
+  RxSwift: 656f8fbeca5bc372121a72d9ebdd3cd3bc0ffade
 
 PODFILE CHECKSUM: 7405369509db0cbd242146add66181ab5ab0efb0
 

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RxNimble"
-  s.version      = "2.0.0"
+  s.version      = "3.0.0"
   s.summary      = "Nimble extensions that making unit testing with RxSwift easier 🎉"
   s.description  = <<-DESC
     This library includes functions that make testing RxSwift projects easier with Nimble.
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
   s.source       = { :git => "https://github.com/ashfurrow/RxNimble.git", :tag => s.version }
   s.source_files  = "Source/**/*.swift"
-  s.dependency "Nimble", "~> 6.0"
+  s.dependency "Nimble", "~> 7.0"
   s.dependency "RxSwift", "~> 3.0"
   s.dependency "RxBlocking", "~> 3.0"
   


### PR DESCRIPTION
I changed the RxNimble pod version to 3.0 since we upgrade a major version of Nimble, but I can change if needed.

The demo still works fine.