### PR TITLE
Add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+## Preparing for development
+
+1. Make sure you have [Carthage](https://github.com/Carthage/Carthage) installed. We use it to pull the RxNimble dependency for development.
+2. Check out this repository.
+3. Do a `carthage update --platform ios --no-use-binaries`
+4. Open `RxNimble.xcodeproj` and start hacking!
+
+## Submitting a Pull Request
+
+When submitting new code, please make sure that it is backed by tests.
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+- (a) The contribution was created in whole or in part by me and I
+      have the right to submit it under the open source license
+      indicated in the file; or
+
+- (b) The contribution is based upon previous work that, to the best
+      of my knowledge, is covered under an appropriate open source
+      license and I have the right under that license to submit that
+      work with modifications, whether created in whole or in part
+      by me, under the same open source license (unless I am
+      permitted to submit under a different license), as indicated
+      in the file; or
+
+- (c) The contribution was provided directly to me by some other
+      person who certified (a), (b) or (c) and I have not modified
+      it.
+
+- (d) I understand and agree that this project and the contribution
+      are public and that a record of the contribution (including all
+      personal information I submit with it, including my sign-off) is
+      maintained indefinitely and may be redistributed consistent with
+      this project or the open source license(s) involved.
+
+*Wording of statement copied from [elinux.org](http://elinux.org/Developer_Certificate_Of_Origin)*

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Nimble extensions that make unit testing with RxSwift easier :tada:
 
+If you came here because you want to help out, please check out [contribution guide](CONTRIBUTING.md)
+
 ## Why
 
 RxSwift includes a really nifty little library called [RxBlocking](http://cocoapods.org/pods/RxBlocking) which provides convenience functions for peeking in on `Observable` instances. Check is a *blocking call*, hence the name. 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Nimble extensions that make unit testing with RxSwift easier :tada:
 
-If you came here because you want to help out, please check out [contribution guide](CONTRIBUTING.md)
+If you came here because you want to help out, please check out the [contribution guide](CONTRIBUTING.md)
 
 ## Why
 


### PR DESCRIPTION
Copied from https://github.com/RxSwiftCommunity/RxSwiftExt/blob/master/CONTRIBUTING.md if @freak4pc will allow that.
It might be quite complicated for cocoapods users to remember which command they should use to install dependencies.
Also added Developer's Certificate of Origin 1.1