### PR TITLE
Pass timeout to blocking operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Support for RxSwift traits
+- Adds support for passing a timeout to RxBlockings' operators
 
 ## 4.5.0
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v8.0.1"
-github "Quick/Quick" "v2.1.0"
+github "Quick/Nimble" "v8.0.4"
+github "Quick/Quick" "v2.2.0"
 github "ReactiveX/RxSwift" "5.0.1"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ expect(observable).first == 42
 
 Nice.
 
+It's also possible to pass a timeout to the blocking operators:
+
+```swift
+expect(observable).first(timeout: 3) == 42
+```
+
 This extension is also available for all Traits (e.g. `Single`, `Maybe`) and other types conforming to `ObservableConvertibleType`.
 
 ---

--- a/RxNimbleTests/RxNimbleRxBlockingTests.swift
+++ b/RxNimbleTests/RxNimbleRxBlockingTests.swift
@@ -5,7 +5,9 @@ import RxNimbleRxBlocking
 
 class RxNimbleRxBlockingTests: QuickSpec {
     override func spec() {
-        //MARK: First
+
+        // MARK: First
+
         describe("First") {
             it("works with plain observables") {
                 let subject = ReplaySubject<String>.createUnbounded()
@@ -35,9 +37,18 @@ class RxNimbleRxBlockingTests: QuickSpec {
 
                 expect(subject).first.to(throwError())
             }
+
+            it("fails if first value is not being emitted in time") {
+                let subject = ReplaySubject<Any>.createUnbounded()
+
+                // Never push onNext
+
+                expect(subject).first(timeout: 1).to(throwError(RxError.timeout))
+            }
         }
 
-        //MARK: Last
+        // MARK: Last
+
         describe("Last") {
             it("checks for last element") {
                 let subject = ReplaySubject<String>.createUnbounded()
@@ -47,12 +58,14 @@ class RxNimbleRxBlockingTests: QuickSpec {
 
                 expect(subject).last == "World"
             }
+
             it("is nil, if sequence is empty") {
                 let subject = ReplaySubject<String>.createUnbounded()
                 subject.onCompleted()
 
                 expect(subject).last.to(beNil())
             }
+
             it("error, if terminated with error") {
                 let subject = ReplaySubject<Any>.createUnbounded()
                 subject.onNext("Hello, world!")
@@ -60,9 +73,19 @@ class RxNimbleRxBlockingTests: QuickSpec {
 
                 expect(subject).last.to(throwError())
             }
+
+            it("fails if last value is not being emitted in time") {
+                let subject = ReplaySubject<Any>.createUnbounded()
+
+                subject.onNext("Hi")
+                // Never complete
+
+                expect(subject).last(timeout: 1).to(throwError(RxError.timeout))
+            }
         }
 
-        //MARK: Array
+        // MARK: Array
+
         describe("Array") {
             it("checks for timeline") {
                 let subject = ReplaySubject<String>.createUnbounded()

--- a/Source/RxBlocking/Expectation+Blocking.swift
+++ b/Source/RxBlocking/Expectation+Blocking.swift
@@ -12,35 +12,60 @@ import RxBlocking
 
 public extension Expectation where T: ObservableConvertibleType {
 
-    /**
-     Expectation with sequence's first element
-     
-     Transforms the expression by blocking sequence and returns its first element.
-    */
+    // MARK: - first
+
+    /// Expectation with sequence's first element
+    ///
+    /// Transforms the expression by blocking sequence and returns its first element.
+    /// - parameter timeout: Maximal time interval waiting for first element to emit before throwing error
+    func first(timeout: TimeInterval? = nil) -> Expectation<T.Element> {
+        return transform { source in
+            try source?.toBlocking(timeout: timeout).first()
+        }
+    }
+
+    /// Expectation with sequence's first element
+    ///
+    /// Transforms the expression by blocking sequence and returns its first element.
     var first: Expectation<T.Element> {
+        return first()
+    }
+
+    // MARK: - last
+
+    /// Expectation with sequence's last element
+    ///
+    /// Transforms the expression by blocking sequence and returns its last element.
+    /// - parameter timeout: Maximal time interval waiting for sequence to complete before throwing error
+    func last(timeout: TimeInterval? = nil) -> Expectation<T.Element> {
         return transform { source in
-            try source?.toBlocking().first()
+            try source?.toBlocking(timeout: timeout).last()
         }
     }
-    /**
-     Expectation with sequence's last element
 
-     Transforms the expression by blocking sequence and returns its last element.
-     */
+    /// Expectation with sequence's last element
+    ///
+    /// Transforms the expression by blocking sequence and returns its last element.
     var last: Expectation<T.Element> {
+        return last()
+    }
+
+    // MARK: - array
+
+    /// Expectation with all sequence's elements
+    ///
+    /// Transforms the expression by blocking sequence and returns its elements.
+    /// - parameter timeout: Maximal time interval waiting for sequence to complete before throwing error
+    func array(timeout: TimeInterval? = nil) -> Expectation<[T.Element]> {
         return transform { source in
-            try source?.toBlocking().last()
+            try source?.toBlocking(timeout: timeout).toArray()
         }
     }
 
-    /**
-     Expectation with all sequence's elements
-
-     Transforms the expression by blocking sequence and returns its elements.
-     */
+    /// Expectation with all sequence's elements
+    ///
+    /// Transforms the expression by blocking sequence and returns its elements.
     var array: Expectation<[T.Element]> {
-        return transform { source in
-            try source?.toBlocking().toArray()
-        }
+        return array()
     }
 }


### PR DESCRIPTION
Hi.

RxBlocking supports passing a `timeout` parameter to its' `toBlocking()` function. This prevents an infinite lock of the run loop in case the expected element is never being emitted.
Unfortunately, currently it's not possible to define such a timeout using RxNimbles' syntactic sugar.

I've created functions which receive an optional `timeout` parameter, which are being used by the respective properties in order to avoid breaking changes. Also, I've updated the dependencies (which happened during initial carthage update obviously).

In addition to the changes I've made I'd like to propose having a meaningful default value for the timeout property. When I think about writing unit tests using the blocking operators, I can't imagine a case where I wouldn't want to specify a timeout, as blocking the run loop would hang up the CI job.
What do you think?