### PR TITLE
Make dispose bag optional for building events expectation

### DIFF
--- a/Source/RxTest/Expectation+RxTest.swift
+++ b/Source/RxTest/Expectation+RxTest.swift
@@ -9,17 +9,25 @@ public extension Expectation where T: ObservableConvertibleType {
     ///
     /// - Parameters:
     ///   - scheduler: the scheduler used to record events in virtual time units.
-    ///   - disposeBag: the dispose bag that will dispose all of its resources between tests.
+    ///   - disposeBag: the dispose bag that will dispose all of its resources between tests. If nil, resources will be disposed at default time.
     ///   - initialTime: the time at which subscription/recording should begin.
     /// - Returns: an expectation of the actual events emitted by the observable.
     func events(scheduler: TestScheduler,
-                disposeBag: DisposeBag,
+                disposeBag: DisposeBag? = nil,
                 startAt initialTime: Int = 0) -> Expectation<RecordedEvents<T.Element>> {
         return transform { source in
             let results = scheduler.createObserver(T.Element.self)
 
+            var disposable: Disposable?
             scheduler.scheduleAt(initialTime) {
-                source?.asObservable().subscribe(results).disposed(by: disposeBag)
+                disposable = source?.asObservable().subscribe(results)
+            }
+            if let disposeBag = disposeBag {
+                disposable?.disposed(by: disposeBag)
+            } else {
+                scheduler.scheduleAt(TestScheduler.Defaults.disposed) {
+                    disposable?.dispose()
+                }
             }
             scheduler.start()
 


### PR DESCRIPTION
Allow automatically dispose subscription resources at scheduler's default dispose time instead of passing `disposeBag` for each expectation