### PR TITLE
Don’t use .git suffixes #trivial 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
+        .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.0")),
+        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0"))
+        .package(url: "https://github.com/mRs-/Nimble", .branch("develop")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "5.0.0")),
-        .package(url: "https://github.com/mRs-/Nimble", .branch("develop")),
+        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Swift Package Manager don't like it when you mix and match .git suffixes. Everything breaks then ¯\_(ツ)_/¯.

All of the other Community Packages don't have these suffixes so maybe we can remove them here too to use this with Xcodes SwiftPM integration