### PR TITLE
Removes requirement for specific Carthage version, fixes CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ cache:
     - $HOME/Library/Caches/org.carthage.CarthageKit/dependencies
     - Carthage
 
-before_install:
-  - carthageversion=$(carthage version)
-  - if [ $carthageversion != "0.33.0" ]; then brew uninstall carthage; HOMEBREW_NO_AUTO_UPDATE=1 brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/d453dd956dbfc5b724b0fdaeb14f9480f461479d/Formula/carthage.rb; fi
-
 jobs:
   include:
     - stage: prepare carthage cache


### PR DESCRIPTION
[Example failure](https://travis-ci.org/github/RxSwiftCommunity/RxNimble/jobs/768416973)

I'm not really a Carthage person, but I feel like we should be relying on the version that comes on our CI machine instead would be more reliable (unless we needed a newer version). [Bintray looks like it's deprecating its binary distributions](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) so installing _Carthage itself_ is what's failing. I couldn't find any GitHub issues to explain the 403 on Carthage's repo – I just want CI to work again :shrug: