### PR TITLE
Update Nimble version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.0.0")),
-        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.0.0"))
+        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "9.2.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Source/Core/"
-    ss.dependency "Nimble", "~> 9.2.0"
+    ss.dependency "Nimble", "~> 9.2"
     ss.dependency "RxSwift", "~> 6.0"
   end
 

--- a/RxNimble.podspec
+++ b/RxNimble.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
 
   s.subspec "Core" do |ss|
     ss.source_files  = "Source/Core/"
-    ss.dependency "Nimble", "~> 9.0"
+    ss.dependency "Nimble", "~> 9.2.0"
     ss.dependency "RxSwift", "~> 6.0"
   end
 


### PR DESCRIPTION
In issue [855](https://github.com/Quick/Nimble/issues/855) from Nimble repository correct a problem on compilation process.
This pull request update the version of Nimble dependency to `9.2.0` to correct the problem. This problem is caused on specific command line into Xcode 12.5.

@ashfurrow 
