### PR TITLE
Rename `Predicate` to `Matcher` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet.
+- Rename `Predicate` to `Matcher` to support Xcode 15.
 
 ## 6.3.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Nimble",
       "state" : {
-        "revision" : "ecade0f20e58e55ba3e5f110b701dad88fd40170",
-        "version" : "12.0.0"
+        "revision" : "d616f15123bfb36db1b1075153f73cf40605b39d",
+        "version" : "13.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift", .upToNextMajor(from: "6.0.0")),
-        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "12.0.0")),
+        .package(url: "https://github.com/Quick/Nimble", .upToNextMajor(from: "13.0.0")),
         .package(url: "https://github.com/Quick/Quick", .upToNextMajor(from: "6.1.0")),
     ],
     targets: [

--- a/Sources/RxNimble/RxTest/Equal+RxTest.swift
+++ b/Sources/RxNimble/RxTest/Equal+RxTest.swift
@@ -3,14 +3,14 @@ import RxSwift
 import RxTest
 
 /// A Nimble matcher that succeeds when the actual events are equal to the expected events.
-public func equal<T: Equatable>(_ expectedEvents: RecordedEvents<T>) -> Predicate<RecordedEvents<T>> {
-    return Predicate.define { actualEvents in
+public func equal<T: Equatable>(_ expectedEvents: RecordedEvents<T>) -> Matcher<RecordedEvents<T>> {
+    Matcher.define { actualEvents in
         let actualEquatableEvents = try actualEvents.evaluate()?.map { AnyEquatable(target: $0, comparer: ==) }
         let expectedEquatableEvents = expectedEvents.map { AnyEquatable(target: $0, comparer: ==) }
 
         let matches = (actualEquatableEvents == expectedEquatableEvents)
-        return PredicateResult(bool: matches,
-                               message: .expectedActualValueTo(
+        return MatcherResult(bool: matches,
+                             message: .expectedActualValueTo(
                                 "emit <\(stringify(expectedEquatableEvents))>")
         )
     }

--- a/Sources/RxNimble/RxTest/ThrowError+RxTest.swift
+++ b/Sources/RxNimble/RxTest/ThrowError+RxTest.swift
@@ -4,7 +4,7 @@ import RxTest
 
 /// A Nimble matcher that succeeds when the actual events emit an error
 /// of any type.
-public func throwError<T: Equatable>() -> Predicate<RecordedEvents<T>> {
+public func throwError<T: Equatable>() -> Matcher<RecordedEvents<T>> {
     func extractError(_ recorded: RecordedEvents<T>?) -> [Error]? {
         func extractError<E>(_ recorded: Recorded<Event<E>>) -> Error? {
             return recorded.value.error
@@ -18,7 +18,7 @@ public func throwError<T: Equatable>() -> Predicate<RecordedEvents<T>> {
     }
 
 
-    return Predicate { actualEvents in
+    return Matcher { actualEvents in
         var actualError: Error?
         do {
             let recordedEvents = try actualEvents.evaluate()
@@ -30,9 +30,9 @@ public func throwError<T: Equatable>() -> Predicate<RecordedEvents<T>> {
         }
 
         if let actualError = actualError {
-            return PredicateResult(bool: true, message: .expectedCustomValueTo("throw any error", actual: "<\(actualError)>"))
+            return MatcherResult(bool: true, message: .expectedCustomValueTo("throw any error", actual: "<\(actualError)>"))
         } else {
-            return PredicateResult(bool: false, message: .expectedCustomValueTo("throw any error", actual: "no error"))
+            return MatcherResult(bool: false, message: .expectedCustomValueTo("throw any error", actual: "no error"))
         }
     }
 }


### PR DESCRIPTION
Nimble 13 has renamed `Predicate` to `Matcher` to avoid compile errors in Xcode 15, https://github.com/Quick/Nimble/pull/1090.
This PR updates the dependency to Nimble 13 and does the renaming to solve https://github.com/RxSwiftCommunity/RxNimble/issues/69


